### PR TITLE
Relax `faraday` and `faraday_middleware` dependency versions

### DIFF
--- a/payrix.gemspec
+++ b/payrix.gemspec
@@ -13,8 +13,8 @@ Gem::Specification.new do |spec|
   spec.files         = Dir['lib/**/*.rb']
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "faraday", "~> 0.14.0"
-  spec.add_runtime_dependency "faraday_middleware", "~> 0.12.2"
+  spec.add_runtime_dependency "faraday", "~> 0.14"
+  spec.add_runtime_dependency "faraday_middleware", "~> 0.12"
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
# Description

This PR relaxes the dependency versions for `faraday` and `faraday_middleware` in the `payrix.gemspec`, to support a wider range of versions on the `0.x` Faraday release line. As mentioned in https://github.com/lostisland/faraday/discussions/1413, Faraday still actively maintains the `0.x` release line, and also follows SemVer. This change should still be compatible for existing consumers of this library, and will only allow more versions of Faraday to be supported.

The previous supported versions are.

- `faraday` - `~> 0.14.0` (`>= 0.14.0, < 0.15.0`)
- `faraday_middleware` - `~> 0.12.2` (`>= 0.12.2, < 0.15.0`)

The versions supported with this change would be.

- `faraday` - `~> 0.14` (`>= 0.14.0, < 1.0`)
- `faraday_middleware` - `~> 0.12` (`>= 0.12.0, < 1.0`)

The one potential issue here is with `faraday_middleware`, which technically now supports previous versions between `0.12.0` and `0.12.2`. Based on the CHANGELOG, https://github.com/lostisland/faraday_middleware/releases, this should be okay.

# Testing

I have tested this with the following approach.

I created an empty directory with this `Gemfile` and bundled it successfully.

```ruby
# Gemfile

source 'http://rubygems.org'
ruby '2.6.6'

gem 'faraday', '~> 0.17'
gem 'payrix', git: 'git@github.com:HiMamaInc/payrix.git', branch: 'task/relax-faraday-dependencies'
```

The `Gemfile.lock` looked like this (notice `faraday` installed on the latest version on the `0.x` line).

```ruby
# Gemfile.lock

GIT
  remote: git@github.com:HiMamaInc/payrix.git
  revision: 03f73e3f8b53e10e6bc1d265f5b5ab7838635866
  branch: task/relax-faraday-dependencies
  specs:
    payrix (0.1.2)
      faraday (~> 0.14)
      faraday_middleware (~> 0.12)

GEM
  remote: http://rubygems.org/
  specs:
    faraday (0.17.5)
      multipart-post (>= 1.2, < 3)
    faraday_middleware (0.14.0)
      faraday (>= 0.7.4, < 1.0)
    multipart-post (2.1.1)

PLATFORMS
  x86_64-darwin-19

DEPENDENCIES
  faraday (~> 0.17)
  payrix!

RUBY VERSION
   ruby 2.6.6p146

BUNDLED WITH
   2.3.10
```

I then ran the following script with a personal API key, and got correct data out.

```ruby
require 'payrix'

Payrix.configure do |configuration|
  configuration.api_key = 'XXXXXX'
  configuration.set_test_mode(true)
end

transactions = Payrix::Resource::Txns.new({})

transactions.retrieve

puts transactions.response.first.id

# => t1_txn_626...
```