### PR TITLE
Allow the use of the `expand` parameter when creating resources

### DIFF
--- a/lib/payrix/resource/base.rb
+++ b/lib/payrix/resource/base.rb
@@ -115,9 +115,14 @@ module Payrix
         
         headers = build_headers
         headers['Content-Type'] = "application/json"
+        query_params = []
+        if request_options
+          query_params << request_options.expand if request_options.expand
+        end
+
         method = 'post'
         url = Payrix.configuration.url
-        endpoint = "#{@resource_name}"
+        endpoint = "#{@resource_name}?#{query_params.join('&')}"
         data = to_json
 
         body, status = Payrix::Http::Request.instance.send_http(method, url, endpoint, data, headers)

--- a/lib/payrix/resource/txns.rb
+++ b/lib/payrix/resource/txns.rb
@@ -26,7 +26,7 @@ module Payrix
                :authentication, :authenticationId, :cofType, :copyReason, :originalApproved, 
                :currencyConversion, :serviceCode, :authTokenCustomer, :debtRepayment, :statement, 
                :convenienceFee, :surcharge, :channel, :funded, :fundingEnabled, 
-               :requestSequence, :processedSequence]
+               :requestSequence, :processedSequence, :txnResults, :payment]
 
       attr_accessor *ATTRS
 


### PR DESCRIPTION
**Description**

The goal of this PR is to allow the use of the `expand` parameter, when creating resources. This allows you to also include related resources in the response after creating the main resource in question.