### PR TITLE
[LIGHT-240] Augment errors to Payrix::Exceptions::ApiError

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,11 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'rspec'
+group :development, :test do
+  gem 'pry'
+end
+
+group :test do
+  gem 'rspec'
+  gem 'webmock'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,13 +8,25 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.8.1)
+      public_suffix (>= 2.0.2, < 6.0)
+    coderay (1.1.3)
+    crack (0.4.5)
+      rexml
     diff-lcs (1.5.0)
     faraday (0.17.5)
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.14.0)
       faraday (>= 0.7.4, < 1.0)
+    hashdiff (1.0.1)
+    method_source (1.0.0)
     multipart-post (2.2.0)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    public_suffix (5.0.0)
     rake (10.5.0)
+    rexml (3.2.5)
     rspec (3.11.0)
       rspec-core (~> 3.11.0)
       rspec-expectations (~> 3.11.0)
@@ -28,14 +40,20 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
     rspec-support (3.11.0)
+    webmock (3.18.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
 
 PLATFORMS
   x86_64-darwin-19
 
 DEPENDENCIES
   payrix!
+  pry
   rake (~> 10.0)
   rspec
+  webmock
 
 BUNDLED WITH
    2.3.10

--- a/lib/payrix/resource/base.rb
+++ b/lib/payrix/resource/base.rb
@@ -111,7 +111,7 @@ module Payrix
 
       def create(params = {})
         set(params)
-        
+
         headers = build_headers
         headers['Content-Type'] = "application/json"
         query_params = []
@@ -133,14 +133,14 @@ module Payrix
       def update(params = {})
         set(params)
 
-        if !id 
+        if !id
           if Payrix.configuration.exception_enabled
             raise Payrix::Exceptions::InvalidRequest.new('ID is required for this action')
           else
             return false
           end
         end
-        
+
         headers = build_headers
         headers['Content-Type'] = "application/json"
         method = 'put'
@@ -157,7 +157,7 @@ module Payrix
       def delete(params = {})
         set(params)
 
-        if !id 
+        if !id
           if Payrix.configuration.exception_enabled
             raise Payrix::Exceptions::InvalidRequest.new('ID is required for this delete')
           else
@@ -196,7 +196,7 @@ module Payrix
 
         headers
       end
-      
+
       def build_search(values = {})
         values
           .delete_if { |k, v| v.nil? || v.empty? }
@@ -207,7 +207,7 @@ module Payrix
       def validate_response
         if @response.has_errors?
           if Payrix.configuration.exception_enabled
-            raise Payrix::Exceptions::ApiError.new('There are errors in the response')
+            raise Payrix::Exceptions::ApiError.new("There are errors in the response, #{@response.errors}")
           end
 
           false

--- a/spec/fixtures/payrix/resource/error.json
+++ b/spec/fixtures/payrix/resource/error.json
@@ -1,0 +1,16 @@
+{
+  "response": {
+    "data": [],
+    "details": {
+      "requestId": 1
+    },
+    "errors": [
+      {
+        "code": 13,
+        "severity": 4,
+        "msg": "No such action and/or resource",
+        "errorCode": "invalid_resource"
+      }
+    ]
+  }
+}

--- a/spec/lib/payrix/resource/base_spec.rb
+++ b/spec/lib/payrix/resource/base_spec.rb
@@ -1,0 +1,20 @@
+RSpec.describe Payrix::Resource::Base do
+  Payrix::Resource::Tests = Class.new(Payrix::Resource::Base) do
+    def initialize(params)
+      super(params, [:status, :amount])
+
+      @resource_name = 'test'
+    end
+  end
+
+  let(:resource) { Payrix::Resource::Tests.new(status: '1', amount: '500') }
+
+  it 'raises Payrix::Exceptions::ApiError with the message which includes the errors payload' do
+    expect { resource.create }
+      .to raise_error(Payrix::Exceptions::ApiError)
+      .with_message(
+        'There are errors in the response, '\
+        '[{"code"=>13, "severity"=>4, "msg"=>"No such action and/or resource", "errorCode"=>"invalid_resource"}]',
+      )
+  end
+end

--- a/spec/lib/payrix/resource/base_spec.rb
+++ b/spec/lib/payrix/resource/base_spec.rb
@@ -9,6 +9,15 @@ RSpec.describe Payrix::Resource::Base do
 
   let(:resource) { Payrix::Resource::Tests.new(status: '1', amount: '500') }
 
+  before do
+    fixture_base_path = File.join('spec', 'fixtures', 'payrix', 'resource')
+    fixture_file_path = File.join(fixture_base_path, 'error.json')
+
+    WebMock
+      .stub_request(:post, 'https://test-api.payrix.com/test')
+      .to_return(body: File.read(fixture_file_path), status: 200)
+  end
+
   it 'raises Payrix::Exceptions::ApiError with the message which includes the errors payload' do
     expect { resource.create }
       .to raise_error(Payrix::Exceptions::ApiError)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,6 @@
 require 'payrix'
+require 'webmock/rspec'
+require 'pry'
 
 RSpec.configure do |config|
   config.expect_with :rspec do |c|
@@ -7,3 +9,9 @@ RSpec.configure do |config|
 
   config.expose_dsl_globally = false
 end
+
+Payrix.configure do |config|
+  config.set_test_mode(true)
+end
+
+WebMock.disable_net_connect!(allow: 'https://test-api.payrix.com/')


### PR DESCRIPTION
**Description**
This PR augments the response error payload to `Payrix::Exceptions::ApiError`. This helps us to improve error insights while debugging.

Jira Issue: [LIGHT-240](https://himama.atlassian.net/browse/LIGHT-240)

**What to Test**
- [x] Test passes `rspec spec`
