### PR TITLE
Change API for setting the request environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## Unreleased
+
+### Breaking Changes
+
+- Change API for setting request environment.
+  - Replace `Payrix.test_mode = true` with `Payrix.environment = :sandbox`.
+  - Replace `Payrix.test_mode = false` with `Payrix.environment = :production`.
+
+### Removals
+
+- Remove `Payrix.test_mode` configuration.
+
 ## 1.0.0 (2023-11-27)
 
 - Interact with the Payrix API!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Change API for setting request environment.
   - Replace `Payrix.test_mode = true` with `Payrix.environment = :sandbox`.
   - Replace `Payrix.test_mode = false` with `Payrix.environment = :production`.
+- Change default request environment to `:sandbox`.
+  - Set `Payrix.environment = :production` to keep existing behaviour.
 
 ### Removals
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 - Remove `Payrix.test_mode` configuration.
 
+### Additions
+
+- Support per-request `:environment` configuration for all CRUD operations.
+
 ## 1.0.0 (2023-11-27)
 
 - Interact with the Payrix API!

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ end
 There are a few configuration parameters.
 
 - `Payrix.api_key=` - Use this to set the API key.
-- `Payrix.test_mode=` - Set `true` to use the Sandbox environment, and `false` use the Production environment.
+- `Payrix.environment=` - Use this to set the request environment. Set to `:sandbox` or `:production`.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -240,14 +240,16 @@ merchant.members # => [...}
 
 #### Per Request Configuration
 
-Pass in `:api_key` to set the API key used per request.
+Set the following configuration parameters per request.
+
+- `:api_key` - Set the API key used.
+- `:environment` - Set the environment used (see valid values in Configuration below).
 
 ```ruby
-Payrix::Merchant.retrieve('t1_mer_620acd189522582b3fb7849', { api_key: 'b442...' })
+Payrix::Merchant.retrieve('t1_mer_620acd189522582b3fb7849', { api_key: 'b442...', environment: :production })
 ```
 
-This is useful if you need to set the API key in a thread-safe way, which is not possible through
-`Payrix.api_key=`. If both are set, the per request configuration takes precedent.
+This is useful if you need to configure the request in a thread-safe way. This is not possible using the static configuration mentioned in Configuration below. The per-request configuration always takes precedent.
 
 ### Errors
 

--- a/lib/payrix.rb
+++ b/lib/payrix.rb
@@ -19,6 +19,11 @@ require 'payrix/resources'
 
 # The Payrix API.
 module Payrix
+  ENVIRONMENTS = {
+    sandbox: :sandbox,
+    production: :production,
+  }.freeze
+
   class << self
     attr_writer :configuration
   end
@@ -31,8 +36,8 @@ module Payrix
     configuration.api_key = api_key
   end
 
-  def self.test_mode=(test_mode)
-    configuration.test_mode = test_mode
+  def self.environment=(environment)
+    configuration.environment = environment
   end
 
   def self.configure

--- a/lib/payrix/client.rb
+++ b/lib/payrix/client.rb
@@ -4,7 +4,7 @@ module Payrix
   # The Payrix::Client is used both internally and externally to initiate API requests to the Payrix API.
   class Client
     def request(method:, resource:, data: {}, filters: {}, options: {})
-      url = Payrix.configuration.url
+      url = Payrix.configuration.url(options[:environment])
 
       page_number = Payrix::RequestOptions::Page::Number.construct(options[:page])
       page_limit = Payrix::RequestOptions::Page::Limit.construct(options[:limit])

--- a/lib/payrix/configuration.rb
+++ b/lib/payrix/configuration.rb
@@ -3,18 +3,19 @@
 module Payrix
   # Use this class to configure API parameters such as API URL, API key, etc.
   class Configuration
-    attr_accessor :api_key, :session_key, :test_mode
+    attr_accessor :api_key, :session_key, :environment
 
     def initialize
       @api_key = ''
       @session_key = ''
-      @test_mode = false
+      @environment = Payrix::ENVIRONMENTS.fetch(:production)
     end
 
     def url
-      if @test_mode
+      case @environment
+      when Payrix::ENVIRONMENTS.fetch(:sandbox)
         'https://test-api.payrix.com'
-      else
+      when Payrix::ENVIRONMENTS.fetch(:production)
         'https://api.payrix.com'
       end
     end

--- a/lib/payrix/configuration.rb
+++ b/lib/payrix/configuration.rb
@@ -3,12 +3,19 @@
 module Payrix
   # Use this class to configure API parameters such as API URL, API key, etc.
   class Configuration
-    attr_accessor :api_key, :session_key, :environment
+    attr_accessor :api_key, :session_key
+    attr_reader :environment
 
     def initialize
       @api_key = ''
       @session_key = ''
       @environment = Payrix::ENVIRONMENTS.fetch(:sandbox)
+    end
+
+    def environment=(environment)
+      validate_environment!(environment)
+
+      @environment = environment.to_sym
     end
 
     def url
@@ -18,6 +25,13 @@ module Payrix
       when Payrix::ENVIRONMENTS.fetch(:production)
         'https://api.payrix.com'
       end
+    end
+
+    private
+
+    def validate_environment!(environment)
+      raise InvalidEnvironmentError unless environment.respond_to?(:to_sym)
+      raise InvalidEnvironmentError unless Payrix::ENVIRONMENTS.values.include?(environment.to_sym)
     end
   end
 end

--- a/lib/payrix/configuration.rb
+++ b/lib/payrix/configuration.rb
@@ -18,8 +18,16 @@ module Payrix
       @environment = environment.to_sym
     end
 
-    def url
-      case @environment
+    def url(environment_override = nil)
+      environment = @environment
+
+      unless environment_override.nil?
+        validate_environment!(environment_override)
+
+        environment = environment_override.to_sym
+      end
+
+      case environment
       when Payrix::ENVIRONMENTS.fetch(:sandbox)
         'https://test-api.payrix.com'
       when Payrix::ENVIRONMENTS.fetch(:production)

--- a/lib/payrix/configuration.rb
+++ b/lib/payrix/configuration.rb
@@ -8,7 +8,7 @@ module Payrix
     def initialize
       @api_key = ''
       @session_key = ''
-      @environment = Payrix::ENVIRONMENTS.fetch(:production)
+      @environment = Payrix::ENVIRONMENTS.fetch(:sandbox)
     end
 
     def url

--- a/lib/payrix/errors.rb
+++ b/lib/payrix/errors.rb
@@ -42,6 +42,10 @@ module Payrix
   class NotFoundError < Error
   end
 
+  # A pre-flight error indicating that the environment set is not valid.
+  class InvalidEnvironmentError < Error
+  end
+
   # An error returned when the API returns an invalid authentication error.
   class InvalidAuthenticationError < Error
   end

--- a/spec/lib/payrix/api_operations/create_spec.rb
+++ b/spec/lib/payrix/api_operations/create_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Payrix::APIOperations::Create do
       it 'raises Payrix::ApiError' do
         stub =
           WebMock
-            .stub_request(:post, 'https://api.payrix.com/txns')
+            .stub_request(:post, 'https://test-api.payrix.com/txns')
             .with(
               body: {
                 total: -1,
@@ -91,7 +91,7 @@ RSpec.describe Payrix::APIOperations::Create do
       it 'returns the created object' do
         stub =
           WebMock
-            .stub_request(:post, 'https://api.payrix.com/txns')
+            .stub_request(:post, 'https://test-api.payrix.com/txns')
             .with(
               body: {
                 total: 100_00,
@@ -132,7 +132,7 @@ RSpec.describe Payrix::APIOperations::Create do
       it 'supports resource expansion via the :expand key' do
         stub =
           WebMock
-            .stub_request(:post, 'https://api.payrix.com/txns?expand[merchant][]=')
+            .stub_request(:post, 'https://test-api.payrix.com/txns?expand[merchant][]=')
             .with(
               body: {
                 total: 100_00,
@@ -176,7 +176,7 @@ RSpec.describe Payrix::APIOperations::Create do
       it 'supports setting the API key per-request via the :api_key key' do
         stub =
           WebMock
-            .stub_request(:post, 'https://api.payrix.com/txns')
+            .stub_request(:post, 'https://test-api.payrix.com/txns')
             .with(
               body: {
                 total: 100_00,

--- a/spec/lib/payrix/api_operations/delete_spec.rb
+++ b/spec/lib/payrix/api_operations/delete_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Payrix::APIOperations::Delete do
       it 'raises Payrix::ApiError' do
         stub =
           WebMock
-            .stub_request(:delete, 'https://api.payrix.com/txns/t1_txn_64026b07cc6a79dd5cfd0da')
+            .stub_request(:delete, 'https://test-api.payrix.com/txns/t1_txn_64026b07cc6a79dd5cfd0da')
             .to_return(
               status: 200,
               body: {
@@ -78,7 +78,7 @@ RSpec.describe Payrix::APIOperations::Delete do
       it 'returns the deleted object' do
         stub =
           WebMock
-            .stub_request(:delete, 'https://api.payrix.com/txns/t1_txn_64026b07cc6a79dd5cfd0da')
+            .stub_request(:delete, 'https://test-api.payrix.com/txns/t1_txn_64026b07cc6a79dd5cfd0da')
             .to_return(
               status: 200,
               body: {
@@ -109,7 +109,7 @@ RSpec.describe Payrix::APIOperations::Delete do
       it 'supports setting the API key per-request via the :api_key key' do
         stub =
           WebMock
-            .stub_request(:delete, 'https://api.payrix.com/txns/t1_txn_64026b07cc6a79dd5cfd0da')
+            .stub_request(:delete, 'https://test-api.payrix.com/txns/t1_txn_64026b07cc6a79dd5cfd0da')
             .with(
               headers: {
                 'Apikey' => 'my-personal-key',

--- a/spec/lib/payrix/api_operations/retrieve_spec.rb
+++ b/spec/lib/payrix/api_operations/retrieve_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Payrix::APIOperations::Retrieve do
     context 'when passing a string, and the API response contains errors' do
       it 'raises Payrix::ApiError' do
         WebMock
-          .stub_request(:get, 'https://api.payrix.com/txns')
+          .stub_request(:get, 'https://test-api.payrix.com/txns')
           .with(
             headers: {
               'Search' => 'id[equals]=t1_txn_64026b07cc6a79dd5cfd0da',
@@ -78,7 +78,7 @@ RSpec.describe Payrix::APIOperations::Retrieve do
     context 'when passing a string, and the API response is empty' do
       it 'raises Payrix::NotFoundError' do
         WebMock
-          .stub_request(:get, 'https://api.payrix.com/txns')
+          .stub_request(:get, 'https://test-api.payrix.com/txns')
           .with(
             headers: {
               'Search' => 'id[equals]=t1_txn_64026b07cc6a79dd5cfd0da',
@@ -110,7 +110,7 @@ RSpec.describe Payrix::APIOperations::Retrieve do
     context 'when passing a string and the API response is not empty' do
       it 'returns an object' do
         WebMock
-          .stub_request(:get, 'https://api.payrix.com/txns')
+          .stub_request(:get, 'https://test-api.payrix.com/txns')
           .with(
             headers: {
               'Search' => 'id[equals]=t1_txn_64026b07cc6a79dd5cfd0da',
@@ -150,7 +150,7 @@ RSpec.describe Payrix::APIOperations::Retrieve do
     context 'when passing a string and an options hash' do
       it 'supports resource expansion via the :expand key' do
         WebMock
-          .stub_request(:get, 'https://api.payrix.com/txns?expand[merchant][]=')
+          .stub_request(:get, 'https://test-api.payrix.com/txns?expand[merchant][]=')
           .with(
             headers: {
               'Search' => 'id[equals]=t1_txn_64026b07cc6a79dd5cfd0da',
@@ -193,7 +193,7 @@ RSpec.describe Payrix::APIOperations::Retrieve do
       it 'supports setting the API key per-request via the :api_key key' do
         stub =
           WebMock
-            .stub_request(:get, 'https://api.payrix.com/txns')
+            .stub_request(:get, 'https://test-api.payrix.com/txns')
             .with(
               headers: {
                 'Apikey' => 'my-personal-key',

--- a/spec/lib/payrix/api_operations/update_spec.rb
+++ b/spec/lib/payrix/api_operations/update_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe Payrix::APIOperations::Update do
       it 'raises Payrix::ApiError' do
         stub =
           WebMock
-            .stub_request(:put, 'https://api.payrix.com/customers/t1_cus_64d511636b66052bb4dec9c')
+            .stub_request(:put, 'https://test-api.payrix.com/customers/t1_cus_64d511636b66052bb4dec9c')
             .with(
               body: {
                 entity: 't1_ent_640b4c3ddd3dd258e691501',
@@ -120,7 +120,7 @@ RSpec.describe Payrix::APIOperations::Update do
       it 'returns the created object' do
         stub =
           WebMock
-            .stub_request(:put, 'https://api.payrix.com/customers/t1_cus_64d511636b66052bb4dec9c')
+            .stub_request(:put, 'https://test-api.payrix.com/customers/t1_cus_64d511636b66052bb4dec9c')
             .with(
               body: {
                 first: 'Joseph',
@@ -159,7 +159,7 @@ RSpec.describe Payrix::APIOperations::Update do
       it 'supports setting the API key per-request via the :api_key key' do
         stub =
           WebMock
-            .stub_request(:put, 'https://api.payrix.com/customers/t1_cus_64d511636b66052bb4dec9c')
+            .stub_request(:put, 'https://test-api.payrix.com/customers/t1_cus_64d511636b66052bb4dec9c')
             .with(
               body: {
                 first: 'Joseph',

--- a/spec/lib/payrix/client_spec.rb
+++ b/spec/lib/payrix/client_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Payrix::Client do
       it 'supports basic requests' do
         stub =
           WebMock
-            .stub_request(:get, 'https://api.payrix.com/txns')
+            .stub_request(:get, 'https://test-api.payrix.com/txns')
             .with(
               headers: {
                 'Content-Type' => 'application/json',
@@ -37,7 +37,7 @@ RSpec.describe Payrix::Client do
           WebMock
             .stub_request(
               :get,
-              'https://api.payrix.com/txns?page[number]=1&page[limit]=10&expand[merchant][]=',
+              'https://test-api.payrix.com/txns?page[number]=1&page[limit]=10&expand[merchant][]=',
             )
             .with(
               headers: {
@@ -80,7 +80,7 @@ RSpec.describe Payrix::Client do
       it 'supports basic requests' do
         stub =
           WebMock
-            .stub_request(:post, 'https://api.payrix.com/txns')
+            .stub_request(:post, 'https://test-api.payrix.com/txns')
             .with(
               headers: {
                 'Content-Type' => 'application/json',
@@ -110,7 +110,7 @@ RSpec.describe Payrix::Client do
       it 'supports advanced requests' do
         stub =
           WebMock
-            .stub_request(:post, 'https://api.payrix.com/txns?expand[merchant][]=')
+            .stub_request(:post, 'https://test-api.payrix.com/txns?expand[merchant][]=')
             .with(
               headers: {
                 'Content-Type' => 'application/json',
@@ -154,7 +154,7 @@ RSpec.describe Payrix::Client do
       it 'supports basic requests' do
         stub =
           WebMock
-            .stub_request(:put, 'https://api.payrix.com/txns/t1_txn_64026b07cc6a79dd5cfd0da')
+            .stub_request(:put, 'https://test-api.payrix.com/txns/t1_txn_64026b07cc6a79dd5cfd0da')
             .with(
               headers: {
                 'Content-Type' => 'application/json',
@@ -192,7 +192,7 @@ RSpec.describe Payrix::Client do
       it 'supports advanced requests' do
         stub =
           WebMock
-            .stub_request(:put, 'https://api.payrix.com/txns/t1_txn_64026b07cc6a79dd5cfd0da')
+            .stub_request(:put, 'https://test-api.payrix.com/txns/t1_txn_64026b07cc6a79dd5cfd0da')
             .with(
               headers: {
                 'Content-Type' => 'application/json',
@@ -235,7 +235,7 @@ RSpec.describe Payrix::Client do
       it 'supports basic requests' do
         stub =
           WebMock
-            .stub_request(:delete, 'https://api.payrix.com/txns/t1_txn_64026b07cc6a79dd5cfd0da')
+            .stub_request(:delete, 'https://test-api.payrix.com/txns/t1_txn_64026b07cc6a79dd5cfd0da')
             .with(
               headers: {
                 'Content-Type' => 'application/json',
@@ -261,7 +261,7 @@ RSpec.describe Payrix::Client do
       it 'supports advanced requests' do
         stub =
           WebMock
-            .stub_request(:delete, 'https://api.payrix.com/txns/t1_txn_64026b07cc6a79dd5cfd0da')
+            .stub_request(:delete, 'https://test-api.payrix.com/txns/t1_txn_64026b07cc6a79dd5cfd0da')
             .with(
               headers: {
                 'Content-Type' => 'application/json',

--- a/spec/lib/payrix/client_spec.rb
+++ b/spec/lib/payrix/client_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Payrix::Client do
           WebMock
             .stub_request(
               :get,
-              'https://test-api.payrix.com/txns?page[number]=1&page[limit]=10&expand[merchant][]=',
+              'https://api.payrix.com/txns?page[number]=1&page[limit]=10&expand[merchant][]=',
             )
             .with(
               headers: {
@@ -68,6 +68,7 @@ RSpec.describe Payrix::Client do
                 limit: 10,
                 expand: ['merchant'],
                 api_key: 'custom-key',
+                environment: :production,
               },
             )
 
@@ -110,7 +111,7 @@ RSpec.describe Payrix::Client do
       it 'supports advanced requests' do
         stub =
           WebMock
-            .stub_request(:post, 'https://test-api.payrix.com/txns?expand[merchant][]=')
+            .stub_request(:post, 'https://api.payrix.com/txns?expand[merchant][]=')
             .with(
               headers: {
                 'Content-Type' => 'application/json',
@@ -142,6 +143,7 @@ RSpec.describe Payrix::Client do
               options: {
                 expand: ['merchant'],
                 api_key: 'custom-key',
+                environment: :production,
               },
             )
 
@@ -192,7 +194,7 @@ RSpec.describe Payrix::Client do
       it 'supports advanced requests' do
         stub =
           WebMock
-            .stub_request(:put, 'https://test-api.payrix.com/txns/t1_txn_64026b07cc6a79dd5cfd0da')
+            .stub_request(:put, 'https://api.payrix.com/txns/t1_txn_64026b07cc6a79dd5cfd0da')
             .with(
               headers: {
                 'Content-Type' => 'application/json',
@@ -223,6 +225,7 @@ RSpec.describe Payrix::Client do
               },
               options: {
                 api_key: 'custom-key',
+                environment: :production,
               },
             )
 
@@ -261,7 +264,7 @@ RSpec.describe Payrix::Client do
       it 'supports advanced requests' do
         stub =
           WebMock
-            .stub_request(:delete, 'https://test-api.payrix.com/txns/t1_txn_64026b07cc6a79dd5cfd0da')
+            .stub_request(:delete, 'https://api.payrix.com/txns/t1_txn_64026b07cc6a79dd5cfd0da')
             .with(
               headers: {
                 'Content-Type' => 'application/json',
@@ -286,6 +289,7 @@ RSpec.describe Payrix::Client do
               resource: 'txns/t1_txn_64026b07cc6a79dd5cfd0da',
               options: {
                 api_key: 'custom-key',
+                environment: :production,
               },
             )
 

--- a/spec/lib/payrix/configuration_spec.rb
+++ b/spec/lib/payrix/configuration_spec.rb
@@ -22,8 +22,16 @@ RSpec.describe Payrix::Configuration do
   end
 
   describe '#url' do
-    context 'when in test mode' do
-      it 'returns https://test-api.payrix.com' do
+    context 'when test mode setting is not configured' do
+      it 'returns the production URL https://api.payrix.com' do
+        configuration = described_class.new
+
+        expect(configuration.url).to eq('https://api.payrix.com')
+      end
+    end
+
+    context 'when test mode setting is enabled' do
+      it 'returns the sandbox URL https://test-api.payrix.com' do
         configuration = described_class.new
 
         configuration.test_mode = true
@@ -32,8 +40,8 @@ RSpec.describe Payrix::Configuration do
       end
     end
 
-    context 'when not in test mode' do
-      it 'returns https://api.payrix.com' do
+    context 'when test mode setting is disabled' do
+      it 'returns the production URL https://api.payrix.com' do
         configuration = described_class.new
 
         configuration.test_mode = false

--- a/spec/lib/payrix/configuration_spec.rb
+++ b/spec/lib/payrix/configuration_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Payrix::Configuration do
   end
 
   describe '#url' do
-    context 'when test mode setting is not configured' do
+    context 'when environment is not configured' do
       it 'returns the production URL https://api.payrix.com' do
         configuration = described_class.new
 
@@ -30,21 +30,21 @@ RSpec.describe Payrix::Configuration do
       end
     end
 
-    context 'when test mode setting is enabled' do
+    context 'when environment is set to sandbox' do
       it 'returns the sandbox URL https://test-api.payrix.com' do
         configuration = described_class.new
 
-        configuration.test_mode = true
+        configuration.environment = :sandbox
 
         expect(configuration.url).to eq('https://test-api.payrix.com')
       end
     end
 
-    context 'when test mode setting is disabled' do
+    context 'when environment is set to production' do
       it 'returns the production URL https://api.payrix.com' do
         configuration = described_class.new
 
-        configuration.test_mode = false
+        configuration.environment = :production
 
         expect(configuration.url).to eq('https://api.payrix.com')
       end

--- a/spec/lib/payrix/configuration_spec.rb
+++ b/spec/lib/payrix/configuration_spec.rb
@@ -21,6 +21,61 @@ RSpec.describe Payrix::Configuration do
     expect(configuration.session_key).to eq('7E57C3FD328F8B00B2A72144FE2A1F83')
   end
 
+  describe '#environment=' do
+    context "when set to 'sandbox'" do
+      it 'sets the environment to sandbox' do
+        configuration = described_class.new
+
+        configuration.environment = 'sandbox'
+
+        expect(configuration.environment).to eq(:sandbox)
+      end
+    end
+
+    context 'when set to :sandbox' do
+      it 'sets the environment to sandbox' do
+        configuration = described_class.new
+
+        configuration.environment = :sandbox
+
+        expect(configuration.environment).to eq(:sandbox)
+      end
+    end
+
+    context "when set to 'production'" do
+      it 'sets the environment to production' do
+        configuration = described_class.new
+
+        configuration.environment = 'production'
+
+        expect(configuration.environment).to eq(:production)
+      end
+    end
+
+    context 'when set to :production' do
+      it 'sets the environment to production' do
+        configuration = described_class.new
+
+        configuration.environment = :production
+
+        expect(configuration.environment).to eq(:production)
+      end
+    end
+
+    context 'when set to an unsupported value' do
+      it 'raises Payrix::InvalidEnvironmentError' do
+        configuration = described_class.new
+
+        expect { configuration.environment = true }.to raise_error(Payrix::InvalidEnvironmentError)
+        expect { configuration.environment = 0 }.to raise_error(Payrix::InvalidEnvironmentError)
+        expect { configuration.environment = :test }.to raise_error(Payrix::InvalidEnvironmentError)
+        expect { configuration.environment = 'test' }.to raise_error(Payrix::InvalidEnvironmentError)
+        expect { configuration.environment = [] }.to raise_error(Payrix::InvalidEnvironmentError)
+        expect { configuration.environment = {} }.to raise_error(Payrix::InvalidEnvironmentError)
+      end
+    end
+  end
+
   describe '#url' do
     context 'when environment is not configured' do
       it 'returns the sandbox URL https://test-api.payrix.com' do

--- a/spec/lib/payrix/configuration_spec.rb
+++ b/spec/lib/payrix/configuration_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Payrix::Configuration do
   end
 
   describe '#url' do
-    context 'when environment is not configured' do
+    context 'when environment is not configured and nothing is passed' do
       it 'returns the sandbox URL https://test-api.payrix.com' do
         configuration = described_class.new
 
@@ -85,7 +85,23 @@ RSpec.describe Payrix::Configuration do
       end
     end
 
-    context 'when environment is set to sandbox' do
+    context 'when environment is not configured and sandbox is passed' do
+      it 'returns the sandbox URL https://test-api.payrix.com' do
+        configuration = described_class.new
+
+        expect(configuration.url(:sandbox)).to eq('https://test-api.payrix.com')
+      end
+    end
+
+    context 'when environment is not configured and production is passed' do
+      it 'returns the production URL https://api.payrix.com' do
+        configuration = described_class.new
+
+        expect(configuration.url(:production)).to eq('https://api.payrix.com')
+      end
+    end
+
+    context 'when environment is set to sandbox and nothing is passed' do
       it 'returns the sandbox URL https://test-api.payrix.com' do
         configuration = described_class.new
 
@@ -95,13 +111,53 @@ RSpec.describe Payrix::Configuration do
       end
     end
 
-    context 'when environment is set to production' do
+    context 'when environment is set to sandbox and sandbox is passed' do
+      it 'returns the sandbox URL https://test-api.payrix.com' do
+        configuration = described_class.new
+
+        configuration.environment = :sandbox
+
+        expect(configuration.url(:sandbox)).to eq('https://test-api.payrix.com')
+      end
+    end
+
+    context 'when environment is set to sandbox and production is passed' do
+      it 'returns the production URL https://api.payrix.com' do
+        configuration = described_class.new
+
+        configuration.environment = :sandbox
+
+        expect(configuration.url(:production)).to eq('https://api.payrix.com')
+      end
+    end
+
+    context 'when environment is set to production and nothing is passed' do
       it 'returns the production URL https://api.payrix.com' do
         configuration = described_class.new
 
         configuration.environment = :production
 
         expect(configuration.url).to eq('https://api.payrix.com')
+      end
+    end
+
+    context 'when environment is set to production and sandbox is passed' do
+      it 'returns the sandbox URL https://test-api.payrix.com' do
+        configuration = described_class.new
+
+        configuration.environment = :production
+
+        expect(configuration.url(:sandbox)).to eq('https://test-api.payrix.com')
+      end
+    end
+
+    context 'when environment is set to production and production is passed' do
+      it 'returns the production URL https://api.payrix.com' do
+        configuration = described_class.new
+
+        configuration.environment = :production
+
+        expect(configuration.url(:production)).to eq('https://api.payrix.com')
       end
     end
   end

--- a/spec/lib/payrix/configuration_spec.rb
+++ b/spec/lib/payrix/configuration_spec.rb
@@ -23,10 +23,10 @@ RSpec.describe Payrix::Configuration do
 
   describe '#url' do
     context 'when environment is not configured' do
-      it 'returns the production URL https://api.payrix.com' do
+      it 'returns the sandbox URL https://test-api.payrix.com' do
         configuration = described_class.new
 
-        expect(configuration.url).to eq('https://api.payrix.com')
+        expect(configuration.url).to eq('https://test-api.payrix.com')
       end
     end
 

--- a/spec/lib/payrix/list_spec.rb
+++ b/spec/lib/payrix/list_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Payrix::List do
     context 'when a hash filter is given' do
       it 'instantiates and requests the 1st page with the filter' do
         WebMock
-          .stub_request(:get, 'https://api.payrix.com/txns?page[number]=1')
+          .stub_request(:get, 'https://test-api.payrix.com/txns?page[number]=1')
           .with(
             headers: {
               'Search' => 'status[equals]=1',
@@ -51,7 +51,7 @@ RSpec.describe Payrix::List do
     context 'when a node filter is given' do
       it 'instantiates and requests the 1st page with the filter' do
         WebMock
-          .stub_request(:get, 'https://api.payrix.com/txns?page[number]=1')
+          .stub_request(:get, 'https://test-api.payrix.com/txns?page[number]=1')
           .with(
             headers: {
               'Search' => 'amount[greater]=10000',
@@ -132,7 +132,7 @@ RSpec.describe Payrix::List do
     context 'when page is nil' do
       it 'instantiates and requests the 1st page' do
         WebMock
-          .stub_request(:get, 'https://api.payrix.com/txns?page[number]=1')
+          .stub_request(:get, 'https://test-api.payrix.com/txns?page[number]=1')
           .to_return(
             status: 200,
             body: {
@@ -174,7 +174,7 @@ RSpec.describe Payrix::List do
     context 'when page is 1' do
       it 'instantiates and requests the 1st page' do
         WebMock
-          .stub_request(:get, 'https://api.payrix.com/txns?page[number]=1')
+          .stub_request(:get, 'https://test-api.payrix.com/txns?page[number]=1')
           .to_return(
             status: 200,
             body: {
@@ -208,7 +208,7 @@ RSpec.describe Payrix::List do
     context 'when page is greater than 1' do
       it 'instantiates and requests the nth page' do
         WebMock
-          .stub_request(:get, 'https://api.payrix.com/txns?page[number]=15')
+          .stub_request(:get, 'https://test-api.payrix.com/txns?page[number]=15')
           .to_return(
             status: 200,
             body: {
@@ -242,7 +242,7 @@ RSpec.describe Payrix::List do
     context 'when limit is given' do
       it 'limits the number of records per page' do
         WebMock
-          .stub_request(:get, 'https://api.payrix.com/txns?page[number]=1&page[limit]=1')
+          .stub_request(:get, 'https://test-api.payrix.com/txns?page[number]=1&page[limit]=1')
           .to_return(
             status: 200,
             body: {
@@ -273,7 +273,7 @@ RSpec.describe Payrix::List do
     context 'when expand is given' do
       it 'supports resource expansion' do
         WebMock
-          .stub_request(:get, 'https://api.payrix.com/txns?page[number]=1&expand[merchant][]=')
+          .stub_request(:get, 'https://test-api.payrix.com/txns?page[number]=1&expand[merchant][]=')
           .to_return(
             status: 200,
             body: {
@@ -311,7 +311,7 @@ RSpec.describe Payrix::List do
       it 'supports setting the API key per-request' do
         stub =
           WebMock
-            .stub_request(:get, 'https://api.payrix.com/txns?page[number]=1')
+            .stub_request(:get, 'https://test-api.payrix.com/txns?page[number]=1')
             .with(
               headers: {
                 'Apikey' => 'my-personal-key',
@@ -348,7 +348,7 @@ RSpec.describe Payrix::List do
   describe 'Pagination' do
     before do
       WebMock
-        .stub_request(:get, 'https://api.payrix.com/txns?page[number]=1')
+        .stub_request(:get, 'https://test-api.payrix.com/txns?page[number]=1')
         .to_return(
           status: 200,
           body: {
@@ -372,7 +372,7 @@ RSpec.describe Payrix::List do
         )
 
       WebMock
-        .stub_request(:get, 'https://api.payrix.com/txns?page[number]=2')
+        .stub_request(:get, 'https://test-api.payrix.com/txns?page[number]=2')
         .to_return(
           status: 200,
           body: {
@@ -396,7 +396,7 @@ RSpec.describe Payrix::List do
         )
 
       WebMock
-        .stub_request(:get, 'https://api.payrix.com/txns?page[number]=3')
+        .stub_request(:get, 'https://test-api.payrix.com/txns?page[number]=3')
         .to_return(
           status: 200,
           body: {


### PR DESCRIPTION
# Description

This PR changes the API for setting the request environment. It is now set through `Payrix.environment=` instead of `Payrix.test_mode=`.

```diff
# Use sandbox environment.
- Payrix.test_mode = true
+ Payrix.environment = :sandbox

# Use production environment.
- Payrix.test_mode = false
+ Payrix.environment = :production
```

Without explicit configuration, the default environment is sandbox now instead of production.

Additionally, support has been added for passing an `:environment` parameter into the `options` hash for all CRUD operations.

```ruby
# `Payrix.environment` is used to determine environment used.
Payrix::Txn.retrieve('t1_txn_64026b07cc6a79dd5cfd0da')

# Use sandbox environment (https://test-api.payrix.com).
Payrix::Txn.retrieve('t1_txn_64026b07cc6a79dd5cfd0da', { environment: :sandbox })

# Use production environment (https://api.payrix.com).
Payrix::Txn.retrieve('t1_txn_64026b07cc6a79dd5cfd0da', { environment: :production })
```