### PR TITLE
Support Payrix Canada API through region configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   - Replace `Payrix.test_mode = false` with `Payrix.environment = :production`.
 - Change default request environment to `:sandbox`.
   - Set `Payrix.environment = :production` to keep existing behaviour.
+- Require specifying the destination API through `Payrix.region=` configuration or a per-request `:region` option.
 
 ### Removals
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ require 'bundler/setup'
 require 'payrix'
 
 Payrix.api_key = '928b...'
+Payrix.region = :us
 
 # Retrieve a single transaction
 Payrix::Txn.retrieve('t1_txn_64026b07cc6a79dd5cfd0da')
@@ -276,6 +277,7 @@ end
 There are a few configuration parameters.
 
 - `Payrix.api_key=` - Use this to set the API key.
+- `Payrix.region=` - Use this to set the appropriate API. Set to `:us`.
 - `Payrix.environment=` - Use this to set the request environment. Set to `:sandbox` or `:production`.
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ end
 There are a few configuration parameters.
 
 - `Payrix.api_key=` - Use this to set the API key.
-- `Payrix.region=` - Use this to set the appropriate API. Set to `:us`.
+- `Payrix.region=` - Use this to set the appropriate API. Set to `:us` or `:ca`.
 - `Payrix.environment=` - Use this to set the request environment. Set to `:sandbox` or `:production`.
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -244,10 +244,11 @@ merchant.members # => [...}
 Set the following configuration parameters per request.
 
 - `:api_key` - Set the API key used.
+- `:region` - Set the API used (see valid values in Configuration below).
 - `:environment` - Set the environment used (see valid values in Configuration below).
 
 ```ruby
-Payrix::Merchant.retrieve('t1_mer_620acd189522582b3fb7849', { api_key: 'b442...', environment: :production })
+Payrix::Merchant.retrieve('t1_mer_620acd189522582b3fb7849', { api_key: 'b442...', region: :ca, environment: :production })
 ```
 
 This is useful if you need to configure the request in a thread-safe way. This is not possible using the static configuration mentioned in Configuration below. The per-request configuration always takes precedent.

--- a/lib/payrix.rb
+++ b/lib/payrix.rb
@@ -24,6 +24,10 @@ module Payrix
     production: :production,
   }.freeze
 
+  REGIONS = {
+    us: :us,
+  }.freeze
+
   class << self
     attr_writer :configuration
   end
@@ -34,6 +38,10 @@ module Payrix
 
   def self.api_key=(api_key)
     configuration.api_key = api_key
+  end
+
+  def self.region=(region)
+    configuration.region = region
   end
 
   def self.environment=(environment)

--- a/lib/payrix.rb
+++ b/lib/payrix.rb
@@ -28,6 +28,13 @@ module Payrix
     us: :us,
   }.freeze
 
+  ENDPOINTS = {
+    REGIONS.fetch(:us) => {
+      ENVIRONMENTS.fetch(:sandbox) => 'https://test-api.payrix.com',
+      ENVIRONMENTS.fetch(:production) => 'https://api.payrix.com',
+    },
+  }.freeze
+
   class << self
     attr_writer :configuration
   end

--- a/lib/payrix.rb
+++ b/lib/payrix.rb
@@ -26,12 +26,17 @@ module Payrix
 
   REGIONS = {
     us: :us,
+    ca: :ca,
   }.freeze
 
   ENDPOINTS = {
     REGIONS.fetch(:us) => {
       ENVIRONMENTS.fetch(:sandbox) => 'https://test-api.payrix.com',
       ENVIRONMENTS.fetch(:production) => 'https://api.payrix.com',
+    },
+    REGIONS.fetch(:ca) => {
+      ENVIRONMENTS.fetch(:sandbox) => 'https://test-api.payrixcanada.com',
+      ENVIRONMENTS.fetch(:production) => 'https://api.payrixcanada.com',
     },
   }.freeze
 

--- a/lib/payrix/client.rb
+++ b/lib/payrix/client.rb
@@ -4,7 +4,7 @@ module Payrix
   # The Payrix::Client is used both internally and externally to initiate API requests to the Payrix API.
   class Client
     def request(method:, resource:, data: {}, filters: {}, options: {})
-      url = Payrix.configuration.url(options[:environment])
+      url = Payrix.configuration.url(options[:region], options[:environment])
 
       page_number = Payrix::RequestOptions::Page::Number.construct(options[:page])
       page_limit = Payrix::RequestOptions::Page::Limit.construct(options[:limit])

--- a/lib/payrix/configuration.rb
+++ b/lib/payrix/configuration.rb
@@ -4,12 +4,19 @@ module Payrix
   # Use this class to configure API parameters such as API URL, API key, etc.
   class Configuration
     attr_accessor :api_key, :session_key
-    attr_reader :environment
+    attr_reader :region, :environment
 
     def initialize
       @api_key = ''
       @session_key = ''
+      @region = nil
       @environment = Payrix::ENVIRONMENTS.fetch(:sandbox)
+    end
+
+    def region=(region)
+      validate_region!(region)
+
+      @region = region.to_sym
     end
 
     def environment=(environment)
@@ -36,6 +43,11 @@ module Payrix
     def validate_environment!(environment)
       raise InvalidEnvironmentError unless environment.respond_to?(:to_sym)
       raise InvalidEnvironmentError unless Payrix::ENVIRONMENTS.values.include?(environment.to_sym)
+    end
+
+    def validate_region!(region)
+      raise InvalidRegionError unless region.respond_to?(:to_sym)
+      raise InvalidRegionError unless Payrix::REGIONS.values.include?(region.to_sym)
     end
   end
 end

--- a/lib/payrix/configuration.rb
+++ b/lib/payrix/configuration.rb
@@ -26,16 +26,13 @@ module Payrix
     end
 
     def url(environment_override = nil)
+      region = @region
       environment = environment_override || @environment
 
+      validate_region!(region)
       validate_environment!(environment)
 
-      case environment.to_sym
-      when Payrix::ENVIRONMENTS.fetch(:sandbox)
-        'https://test-api.payrix.com'
-      when Payrix::ENVIRONMENTS.fetch(:production)
-        'https://api.payrix.com'
-      end
+      Payrix::ENDPOINTS[region.to_sym][environment.to_sym]
     end
 
     private

--- a/lib/payrix/configuration.rb
+++ b/lib/payrix/configuration.rb
@@ -19,15 +19,11 @@ module Payrix
     end
 
     def url(environment_override = nil)
-      environment = @environment
+      environment = environment_override || @environment
 
-      unless environment_override.nil?
-        validate_environment!(environment_override)
+      validate_environment!(environment)
 
-        environment = environment_override.to_sym
-      end
-
-      case environment
+      case environment.to_sym
       when Payrix::ENVIRONMENTS.fetch(:sandbox)
         'https://test-api.payrix.com'
       when Payrix::ENVIRONMENTS.fetch(:production)

--- a/lib/payrix/configuration.rb
+++ b/lib/payrix/configuration.rb
@@ -25,8 +25,8 @@ module Payrix
       @environment = environment.to_sym
     end
 
-    def url(environment_override = nil)
-      region = @region
+    def url(region_override = nil, environment_override = nil)
+      region = region_override || @region
       environment = environment_override || @environment
 
       validate_region!(region)

--- a/lib/payrix/errors.rb
+++ b/lib/payrix/errors.rb
@@ -46,6 +46,10 @@ module Payrix
   class InvalidEnvironmentError < Error
   end
 
+  # A pre-flight error indicating that the region set is not valid.
+  class InvalidRegionError < Error
+  end
+
   # An error returned when the API returns an invalid authentication error.
   class InvalidAuthenticationError < Error
   end

--- a/spec/lib/payrix/client_spec.rb
+++ b/spec/lib/payrix/client_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Payrix::Client do
           WebMock
             .stub_request(
               :get,
-              'https://api.payrix.com/txns?page[number]=1&page[limit]=10&expand[merchant][]=',
+              'https://api.payrixcanada.com/txns?page[number]=1&page[limit]=10&expand[merchant][]=',
             )
             .with(
               headers: {
@@ -68,6 +68,7 @@ RSpec.describe Payrix::Client do
                 limit: 10,
                 expand: ['merchant'],
                 api_key: 'custom-key',
+                region: :ca,
                 environment: :production,
               },
             )
@@ -111,7 +112,7 @@ RSpec.describe Payrix::Client do
       it 'supports advanced requests' do
         stub =
           WebMock
-            .stub_request(:post, 'https://api.payrix.com/txns?expand[merchant][]=')
+            .stub_request(:post, 'https://api.payrixcanada.com/txns?expand[merchant][]=')
             .with(
               headers: {
                 'Content-Type' => 'application/json',
@@ -143,6 +144,7 @@ RSpec.describe Payrix::Client do
               options: {
                 expand: ['merchant'],
                 api_key: 'custom-key',
+                region: :ca,
                 environment: :production,
               },
             )
@@ -194,7 +196,7 @@ RSpec.describe Payrix::Client do
       it 'supports advanced requests' do
         stub =
           WebMock
-            .stub_request(:put, 'https://api.payrix.com/txns/t1_txn_64026b07cc6a79dd5cfd0da')
+            .stub_request(:put, 'https://api.payrixcanada.com/txns/t1_txn_64026b07cc6a79dd5cfd0da')
             .with(
               headers: {
                 'Content-Type' => 'application/json',
@@ -225,6 +227,7 @@ RSpec.describe Payrix::Client do
               },
               options: {
                 api_key: 'custom-key',
+                region: :ca,
                 environment: :production,
               },
             )
@@ -264,7 +267,7 @@ RSpec.describe Payrix::Client do
       it 'supports advanced requests' do
         stub =
           WebMock
-            .stub_request(:delete, 'https://api.payrix.com/txns/t1_txn_64026b07cc6a79dd5cfd0da')
+            .stub_request(:delete, 'https://api.payrixcanada.com/txns/t1_txn_64026b07cc6a79dd5cfd0da')
             .with(
               headers: {
                 'Content-Type' => 'application/json',
@@ -289,6 +292,7 @@ RSpec.describe Payrix::Client do
               resource: 'txns/t1_txn_64026b07cc6a79dd5cfd0da',
               options: {
                 api_key: 'custom-key',
+                region: :ca,
                 environment: :production,
               },
             )

--- a/spec/lib/payrix/configuration_spec.rb
+++ b/spec/lib/payrix/configuration_spec.rb
@@ -132,17 +132,35 @@ RSpec.describe Payrix::Configuration do
   end
 
   describe '#url' do
+    # rubocop:disable RSpec/NestedGroups
     describe 'region is not configured' do
-      it 'raises Payrix::InvalidRegionError' do
-        configuration = described_class.new
+      context 'when region override is not passed' do
+        it 'raises Payrix::InvalidRegionError' do
+          configuration = described_class.new
 
-        expect { configuration.url }.to raise_error(Payrix::InvalidRegionError)
+          expect { configuration.url }.to raise_error(Payrix::InvalidRegionError)
+        end
+      end
+
+      context 'when region override is passed (us)' do
+        it 'returns the sandbox URL https://test-api.payrix.com' do
+          configuration = described_class.new
+
+          expect(configuration.url(:us)).to eq('https://test-api.payrix.com')
+        end
+      end
+
+      context 'when region override is passed (ca)' do
+        it 'returns the sandbox URL https://test-api.payrixcanada.com' do
+          configuration = described_class.new
+
+          expect(configuration.url(:ca)).to eq('https://test-api.payrixcanada.com')
+        end
       end
     end
 
-    # rubocop:disable RSpec/NestedGroups
     describe 'region is US' do
-      context 'when environment is not configured and nothing is passed' do
+      context 'when environment not configured, no environment override, no region override' do
         it 'returns the sandbox URL https://test-api.payrix.com' do
           configuration = described_class.new
 
@@ -152,27 +170,57 @@ RSpec.describe Payrix::Configuration do
         end
       end
 
-      context 'when environment is not configured and sandbox is passed' do
+      context 'when environment not configured, no environment override, region override (ca)' do
+        it 'returns the sandbox URL https://test-api.payrixcanada.com' do
+          configuration = described_class.new
+
+          configuration.region = :us
+
+          expect(configuration.url(:ca)).to eq('https://test-api.payrixcanada.com')
+        end
+      end
+
+      context 'when environment not configured, environment override (sandbox), no region override' do
         it 'returns the sandbox URL https://test-api.payrix.com' do
           configuration = described_class.new
 
           configuration.region = :us
 
-          expect(configuration.url(:sandbox)).to eq('https://test-api.payrix.com')
+          expect(configuration.url(nil, :sandbox)).to eq('https://test-api.payrix.com')
         end
       end
 
-      context 'when environment is not configured and production is passed' do
+      context 'when environment not configured, environment override (sandbox), region override (ca)' do
+        it 'returns the sandbox URL https://test-api.payrixcanada.com' do
+          configuration = described_class.new
+
+          configuration.region = :us
+
+          expect(configuration.url(:ca, :sandbox)).to eq('https://test-api.payrixcanada.com')
+        end
+      end
+
+      context 'when environment not configured, environment override (production), no region override' do
         it 'returns the production URL https://api.payrix.com' do
           configuration = described_class.new
 
           configuration.region = :us
 
-          expect(configuration.url(:production)).to eq('https://api.payrix.com')
+          expect(configuration.url(nil, :production)).to eq('https://api.payrix.com')
         end
       end
 
-      context 'when environment is set to sandbox and nothing is passed' do
+      context 'when environment not configured, environment override (production), region override (ca)' do
+        it 'returns the production URL https://api.payrixcanada.com' do
+          configuration = described_class.new
+
+          configuration.region = :us
+
+          expect(configuration.url(:ca, :production)).to eq('https://api.payrixcanada.com')
+        end
+      end
+
+      context 'when environment configured (sandbox), no environment override, no region override' do
         it 'returns the sandbox URL https://test-api.payrix.com' do
           configuration = described_class.new
 
@@ -183,29 +231,62 @@ RSpec.describe Payrix::Configuration do
         end
       end
 
-      context 'when environment is set to sandbox and sandbox is passed' do
+      context 'when environment configured (sandbox), no environment override, region override (ca)' do
+        it 'returns the sandbox URL https://test-api.payrixcanada.com' do
+          configuration = described_class.new
+
+          configuration.region = :us
+          configuration.environment = :sandbox
+
+          expect(configuration.url(:ca)).to eq('https://test-api.payrixcanada.com')
+        end
+      end
+
+      context 'when environment configured (sandbox), environment override (sandbox), no region override' do
         it 'returns the sandbox URL https://test-api.payrix.com' do
           configuration = described_class.new
 
           configuration.region = :us
           configuration.environment = :sandbox
 
-          expect(configuration.url(:sandbox)).to eq('https://test-api.payrix.com')
+          expect(configuration.url(nil, :sandbox)).to eq('https://test-api.payrix.com')
         end
       end
 
-      context 'when environment is set to sandbox and production is passed' do
+      context 'when environment configured (sandbox), environment override (sandbox), region override (ca)' do
+        it 'returns the sandbox URL https://test-api.payrixcanada.com' do
+          configuration = described_class.new
+
+          configuration.region = :us
+          configuration.environment = :sandbox
+
+          expect(configuration.url(:ca, :sandbox)).to eq('https://test-api.payrixcanada.com')
+        end
+      end
+
+      context 'when environment configured (sandbox), environment override (production), no region override' do
         it 'returns the production URL https://api.payrix.com' do
           configuration = described_class.new
 
           configuration.region = :us
           configuration.environment = :sandbox
 
-          expect(configuration.url(:production)).to eq('https://api.payrix.com')
+          expect(configuration.url(nil, :production)).to eq('https://api.payrix.com')
         end
       end
 
-      context 'when environment is set to production and nothing is passed' do
+      context 'when environment configured (sandbox), environment override (production), region override (ca)' do
+        it 'returns the production URL https://api.payrixcanada.com' do
+          configuration = described_class.new
+
+          configuration.region = :us
+          configuration.environment = :sandbox
+
+          expect(configuration.url(:ca, :production)).to eq('https://api.payrixcanada.com')
+        end
+      end
+
+      context 'when environment configured (production), no environment override, no region override' do
         it 'returns the production URL https://api.payrix.com' do
           configuration = described_class.new
 
@@ -216,31 +297,64 @@ RSpec.describe Payrix::Configuration do
         end
       end
 
-      context 'when environment is set to production and sandbox is passed' do
+      context 'when environment configured (production), no environment override, region override (ca)' do
+        it 'returns the production URL https://api.payrixcanada.com' do
+          configuration = described_class.new
+
+          configuration.region = :us
+          configuration.environment = :production
+
+          expect(configuration.url(:ca)).to eq('https://api.payrixcanada.com')
+        end
+      end
+
+      context 'when environment configured (production), environment override (sandbox), no region override' do
         it 'returns the sandbox URL https://test-api.payrix.com' do
           configuration = described_class.new
 
           configuration.region = :us
           configuration.environment = :production
 
-          expect(configuration.url(:sandbox)).to eq('https://test-api.payrix.com')
+          expect(configuration.url(nil, :sandbox)).to eq('https://test-api.payrix.com')
         end
       end
 
-      context 'when environment is set to production and production is passed' do
+      context 'when environment configured (production), environment override (sandbox), region override (ca)' do
+        it 'returns the sandbox URL https://test-api.payrixcanada.com' do
+          configuration = described_class.new
+
+          configuration.region = :us
+          configuration.environment = :production
+
+          expect(configuration.url(:ca, :sandbox)).to eq('https://test-api.payrixcanada.com')
+        end
+      end
+
+      context 'when environment configured (production), environment override (production), no region override' do
         it 'returns the production URL https://api.payrix.com' do
           configuration = described_class.new
 
           configuration.region = :us
           configuration.environment = :production
 
-          expect(configuration.url(:production)).to eq('https://api.payrix.com')
+          expect(configuration.url(nil, :production)).to eq('https://api.payrix.com')
+        end
+      end
+
+      context 'when environment configured (production), environment override (production), region override (ca)' do
+        it 'returns the production URL https://api.payrixcanada.com' do
+          configuration = described_class.new
+
+          configuration.region = :us
+          configuration.environment = :production
+
+          expect(configuration.url(:ca, :production)).to eq('https://api.payrixcanada.com')
         end
       end
     end
 
     describe 'region is CA' do
-      context 'when environment is not configured and nothing is passed' do
+      context 'when environment not configured, no environment override, no region override' do
         it 'returns the sandbox URL https://test-api.payrixcanada.com' do
           configuration = described_class.new
 
@@ -250,27 +364,57 @@ RSpec.describe Payrix::Configuration do
         end
       end
 
-      context 'when environment is not configured and sandbox is passed' do
+      context 'when environment not configured, no environment override, region override (us)' do
+        it 'returns the sandbox URL https://test-api.payrix.com' do
+          configuration = described_class.new
+
+          configuration.region = :ca
+
+          expect(configuration.url(:us)).to eq('https://test-api.payrix.com')
+        end
+      end
+
+      context 'when environment not configured, environment override (sandbox), no region override' do
         it 'returns the sandbox URL https://test-api.payrixcanada.com' do
           configuration = described_class.new
 
           configuration.region = :ca
 
-          expect(configuration.url(:sandbox)).to eq('https://test-api.payrixcanada.com')
+          expect(configuration.url(nil, :sandbox)).to eq('https://test-api.payrixcanada.com')
         end
       end
 
-      context 'when environment is not configured and production is passed' do
+      context 'when environment not configured, environment override (sandbox), region override (us)' do
+        it 'returns the sandbox URL https://test-api.payrix.com' do
+          configuration = described_class.new
+
+          configuration.region = :ca
+
+          expect(configuration.url(:us, :sandbox)).to eq('https://test-api.payrix.com')
+        end
+      end
+
+      context 'when environment not configured, environment override (production), no region override' do
         it 'returns the production URL https://api.payrixcanada.com' do
           configuration = described_class.new
 
           configuration.region = :ca
 
-          expect(configuration.url(:production)).to eq('https://api.payrixcanada.com')
+          expect(configuration.url(nil, :production)).to eq('https://api.payrixcanada.com')
         end
       end
 
-      context 'when environment is set to sandbox and nothing is passed' do
+      context 'when environment not configured, environment override (production), region override (us)' do
+        it 'returns the production URL https://api.payrix.com' do
+          configuration = described_class.new
+
+          configuration.region = :ca
+
+          expect(configuration.url(:us, :production)).to eq('https://api.payrix.com')
+        end
+      end
+
+      context 'when environment configured (sandbox), no environment override, no region override' do
         it 'returns the sandbox URL https://test-api.payrixcanada.com' do
           configuration = described_class.new
 
@@ -281,29 +425,62 @@ RSpec.describe Payrix::Configuration do
         end
       end
 
-      context 'when environment is set to sandbox and sandbox is passed' do
+      context 'when environment configured (sandbox), no environment override, region override (us)' do
+        it 'returns the sandbox URL https://test-api.payrix.com' do
+          configuration = described_class.new
+
+          configuration.region = :ca
+          configuration.environment = :sandbox
+
+          expect(configuration.url(:us)).to eq('https://test-api.payrix.com')
+        end
+      end
+
+      context 'when environment configured (sandbox), environment override (sandbox), no region override' do
         it 'returns the sandbox URL https://test-api.payrixcanada.com' do
           configuration = described_class.new
 
           configuration.region = :ca
           configuration.environment = :sandbox
 
-          expect(configuration.url(:sandbox)).to eq('https://test-api.payrixcanada.com')
+          expect(configuration.url(nil, :sandbox)).to eq('https://test-api.payrixcanada.com')
         end
       end
 
-      context 'when environment is set to sandbox and production is passed' do
+      context 'when environment configured (sandbox), environment override (sandbox), region override (us)' do
+        it 'returns the sandbox URL https://test-api.payrix.com' do
+          configuration = described_class.new
+
+          configuration.region = :ca
+          configuration.environment = :sandbox
+
+          expect(configuration.url(:us, :sandbox)).to eq('https://test-api.payrix.com')
+        end
+      end
+
+      context 'when environment configured (sandbox), environment override (production), no region override' do
         it 'returns the production URL https://api.payrixcanada.com' do
           configuration = described_class.new
 
           configuration.region = :ca
           configuration.environment = :sandbox
 
-          expect(configuration.url(:production)).to eq('https://api.payrixcanada.com')
+          expect(configuration.url(nil, :production)).to eq('https://api.payrixcanada.com')
         end
       end
 
-      context 'when environment is set to production and nothing is passed' do
+      context 'when environment configured (sandbox), environment override (production), region override (us)' do
+        it 'returns the production URL https://api.payrix.com' do
+          configuration = described_class.new
+
+          configuration.region = :ca
+          configuration.environment = :sandbox
+
+          expect(configuration.url(:us, :production)).to eq('https://api.payrix.com')
+        end
+      end
+
+      context 'when environment configured (production), no environment override, no region override' do
         it 'returns the production URL https://api.payrixcanada.com' do
           configuration = described_class.new
 
@@ -314,25 +491,58 @@ RSpec.describe Payrix::Configuration do
         end
       end
 
-      context 'when environment is set to production and sandbox is passed' do
+      context 'when environment configured (production), no environment override, region override (us)' do
+        it 'returns the production URL https://api.payrix.com' do
+          configuration = described_class.new
+
+          configuration.region = :ca
+          configuration.environment = :production
+
+          expect(configuration.url(:us)).to eq('https://api.payrix.com')
+        end
+      end
+
+      context 'when environment configured (production), environment override (sandbox), no region override' do
         it 'returns the sandbox URL https://test-api.payrixcanada.com' do
           configuration = described_class.new
 
           configuration.region = :ca
           configuration.environment = :production
 
-          expect(configuration.url(:sandbox)).to eq('https://test-api.payrixcanada.com')
+          expect(configuration.url(nil, :sandbox)).to eq('https://test-api.payrixcanada.com')
         end
       end
 
-      context 'when environment is set to production and production is passed' do
+      context 'when environment configured (production), environment override (sandbox), region override (us)' do
+        it 'returns the sandbox URL https://test-api.payrix.com' do
+          configuration = described_class.new
+
+          configuration.region = :ca
+          configuration.environment = :production
+
+          expect(configuration.url(:us, :sandbox)).to eq('https://test-api.payrix.com')
+        end
+      end
+
+      context 'when environment configured (production), environment override (production), no region override' do
         it 'returns the production URL https://api.payrixcanada.com' do
           configuration = described_class.new
 
           configuration.region = :ca
           configuration.environment = :production
 
-          expect(configuration.url(:production)).to eq('https://api.payrixcanada.com')
+          expect(configuration.url(nil, :production)).to eq('https://api.payrixcanada.com')
+        end
+      end
+
+      context 'when environment configured (production), environment override (production), region override (us)' do
+        it 'returns the production URL https://api.payrix.com' do
+          configuration = described_class.new
+
+          configuration.region = :ca
+          configuration.environment = :production
+
+          expect(configuration.url(:us, :production)).to eq('https://api.payrix.com')
         end
       end
     end

--- a/spec/lib/payrix/configuration_spec.rb
+++ b/spec/lib/payrix/configuration_spec.rb
@@ -112,88 +112,112 @@ RSpec.describe Payrix::Configuration do
   end
 
   describe '#url' do
-    context 'when environment is not configured and nothing is passed' do
-      it 'returns the sandbox URL https://test-api.payrix.com' do
+    describe 'region is not configured' do
+      it 'raises Payrix::InvalidRegionError' do
         configuration = described_class.new
 
-        expect(configuration.url).to eq('https://test-api.payrix.com')
+        expect { configuration.url }.to raise_error(Payrix::InvalidRegionError)
       end
     end
 
-    context 'when environment is not configured and sandbox is passed' do
-      it 'returns the sandbox URL https://test-api.payrix.com' do
-        configuration = described_class.new
+    # rubocop:disable RSpec/NestedGroups
+    describe 'region is US' do
+      context 'when environment is not configured and nothing is passed' do
+        it 'returns the sandbox URL https://test-api.payrix.com' do
+          configuration = described_class.new
 
-        expect(configuration.url(:sandbox)).to eq('https://test-api.payrix.com')
+          configuration.region = :us
+
+          expect(configuration.url).to eq('https://test-api.payrix.com')
+        end
+      end
+
+      context 'when environment is not configured and sandbox is passed' do
+        it 'returns the sandbox URL https://test-api.payrix.com' do
+          configuration = described_class.new
+
+          configuration.region = :us
+
+          expect(configuration.url(:sandbox)).to eq('https://test-api.payrix.com')
+        end
+      end
+
+      context 'when environment is not configured and production is passed' do
+        it 'returns the production URL https://api.payrix.com' do
+          configuration = described_class.new
+
+          configuration.region = :us
+
+          expect(configuration.url(:production)).to eq('https://api.payrix.com')
+        end
+      end
+
+      context 'when environment is set to sandbox and nothing is passed' do
+        it 'returns the sandbox URL https://test-api.payrix.com' do
+          configuration = described_class.new
+
+          configuration.region = :us
+          configuration.environment = :sandbox
+
+          expect(configuration.url).to eq('https://test-api.payrix.com')
+        end
+      end
+
+      context 'when environment is set to sandbox and sandbox is passed' do
+        it 'returns the sandbox URL https://test-api.payrix.com' do
+          configuration = described_class.new
+
+          configuration.region = :us
+          configuration.environment = :sandbox
+
+          expect(configuration.url(:sandbox)).to eq('https://test-api.payrix.com')
+        end
+      end
+
+      context 'when environment is set to sandbox and production is passed' do
+        it 'returns the production URL https://api.payrix.com' do
+          configuration = described_class.new
+
+          configuration.region = :us
+          configuration.environment = :sandbox
+
+          expect(configuration.url(:production)).to eq('https://api.payrix.com')
+        end
+      end
+
+      context 'when environment is set to production and nothing is passed' do
+        it 'returns the production URL https://api.payrix.com' do
+          configuration = described_class.new
+
+          configuration.region = :us
+          configuration.environment = :production
+
+          expect(configuration.url).to eq('https://api.payrix.com')
+        end
+      end
+
+      context 'when environment is set to production and sandbox is passed' do
+        it 'returns the sandbox URL https://test-api.payrix.com' do
+          configuration = described_class.new
+
+          configuration.region = :us
+          configuration.environment = :production
+
+          expect(configuration.url(:sandbox)).to eq('https://test-api.payrix.com')
+        end
+      end
+
+      context 'when environment is set to production and production is passed' do
+        it 'returns the production URL https://api.payrix.com' do
+          configuration = described_class.new
+
+          configuration.region = :us
+          configuration.environment = :production
+
+          expect(configuration.url(:production)).to eq('https://api.payrix.com')
+        end
       end
     end
-
-    context 'when environment is not configured and production is passed' do
-      it 'returns the production URL https://api.payrix.com' do
-        configuration = described_class.new
-
-        expect(configuration.url(:production)).to eq('https://api.payrix.com')
-      end
-    end
-
-    context 'when environment is set to sandbox and nothing is passed' do
-      it 'returns the sandbox URL https://test-api.payrix.com' do
-        configuration = described_class.new
-
-        configuration.environment = :sandbox
-
-        expect(configuration.url).to eq('https://test-api.payrix.com')
-      end
-    end
-
-    context 'when environment is set to sandbox and sandbox is passed' do
-      it 'returns the sandbox URL https://test-api.payrix.com' do
-        configuration = described_class.new
-
-        configuration.environment = :sandbox
-
-        expect(configuration.url(:sandbox)).to eq('https://test-api.payrix.com')
-      end
-    end
-
-    context 'when environment is set to sandbox and production is passed' do
-      it 'returns the production URL https://api.payrix.com' do
-        configuration = described_class.new
-
-        configuration.environment = :sandbox
-
-        expect(configuration.url(:production)).to eq('https://api.payrix.com')
-      end
-    end
-
-    context 'when environment is set to production and nothing is passed' do
-      it 'returns the production URL https://api.payrix.com' do
-        configuration = described_class.new
-
-        configuration.environment = :production
-
-        expect(configuration.url).to eq('https://api.payrix.com')
-      end
-    end
-
-    context 'when environment is set to production and sandbox is passed' do
-      it 'returns the sandbox URL https://test-api.payrix.com' do
-        configuration = described_class.new
-
-        configuration.environment = :production
-
-        expect(configuration.url(:sandbox)).to eq('https://test-api.payrix.com')
-      end
-    end
-
-    context 'when environment is set to production and production is passed' do
-      it 'returns the production URL https://api.payrix.com' do
-        configuration = described_class.new
-
-        configuration.environment = :production
-
-        expect(configuration.url(:production)).to eq('https://api.payrix.com')
-      end
-    end
+    # rubocop:enable RSpec/NestedGroups
   end
 end

--- a/spec/lib/payrix/configuration_spec.rb
+++ b/spec/lib/payrix/configuration_spec.rb
@@ -97,6 +97,26 @@ RSpec.describe Payrix::Configuration do
       end
     end
 
+    context "when set to 'ca'" do
+      it 'sets the region to CA' do
+        configuration = described_class.new
+
+        configuration.region = 'ca'
+
+        expect(configuration.region).to eq(:ca)
+      end
+    end
+
+    context 'when set to :ca' do
+      it 'sets the region to CA' do
+        configuration = described_class.new
+
+        configuration.region = :ca
+
+        expect(configuration.region).to eq(:ca)
+      end
+    end
+
     context 'when set to an unsupported value' do
       it 'raises Payrix::InvalidRegionError' do
         configuration = described_class.new
@@ -215,6 +235,104 @@ RSpec.describe Payrix::Configuration do
           configuration.environment = :production
 
           expect(configuration.url(:production)).to eq('https://api.payrix.com')
+        end
+      end
+    end
+
+    describe 'region is CA' do
+      context 'when environment is not configured and nothing is passed' do
+        it 'returns the sandbox URL https://test-api.payrixcanada.com' do
+          configuration = described_class.new
+
+          configuration.region = :ca
+
+          expect(configuration.url).to eq('https://test-api.payrixcanada.com')
+        end
+      end
+
+      context 'when environment is not configured and sandbox is passed' do
+        it 'returns the sandbox URL https://test-api.payrixcanada.com' do
+          configuration = described_class.new
+
+          configuration.region = :ca
+
+          expect(configuration.url(:sandbox)).to eq('https://test-api.payrixcanada.com')
+        end
+      end
+
+      context 'when environment is not configured and production is passed' do
+        it 'returns the production URL https://api.payrixcanada.com' do
+          configuration = described_class.new
+
+          configuration.region = :ca
+
+          expect(configuration.url(:production)).to eq('https://api.payrixcanada.com')
+        end
+      end
+
+      context 'when environment is set to sandbox and nothing is passed' do
+        it 'returns the sandbox URL https://test-api.payrixcanada.com' do
+          configuration = described_class.new
+
+          configuration.region = :ca
+          configuration.environment = :sandbox
+
+          expect(configuration.url).to eq('https://test-api.payrixcanada.com')
+        end
+      end
+
+      context 'when environment is set to sandbox and sandbox is passed' do
+        it 'returns the sandbox URL https://test-api.payrixcanada.com' do
+          configuration = described_class.new
+
+          configuration.region = :ca
+          configuration.environment = :sandbox
+
+          expect(configuration.url(:sandbox)).to eq('https://test-api.payrixcanada.com')
+        end
+      end
+
+      context 'when environment is set to sandbox and production is passed' do
+        it 'returns the production URL https://api.payrixcanada.com' do
+          configuration = described_class.new
+
+          configuration.region = :ca
+          configuration.environment = :sandbox
+
+          expect(configuration.url(:production)).to eq('https://api.payrixcanada.com')
+        end
+      end
+
+      context 'when environment is set to production and nothing is passed' do
+        it 'returns the production URL https://api.payrixcanada.com' do
+          configuration = described_class.new
+
+          configuration.region = :ca
+          configuration.environment = :production
+
+          expect(configuration.url).to eq('https://api.payrixcanada.com')
+        end
+      end
+
+      context 'when environment is set to production and sandbox is passed' do
+        it 'returns the sandbox URL https://test-api.payrixcanada.com' do
+          configuration = described_class.new
+
+          configuration.region = :ca
+          configuration.environment = :production
+
+          expect(configuration.url(:sandbox)).to eq('https://test-api.payrixcanada.com')
+        end
+      end
+
+      context 'when environment is set to production and production is passed' do
+        it 'returns the production URL https://api.payrixcanada.com' do
+          configuration = described_class.new
+
+          configuration.region = :ca
+          configuration.environment = :production
+
+          expect(configuration.url(:production)).to eq('https://api.payrixcanada.com')
         end
       end
     end

--- a/spec/lib/payrix/configuration_spec.rb
+++ b/spec/lib/payrix/configuration_spec.rb
@@ -76,6 +76,41 @@ RSpec.describe Payrix::Configuration do
     end
   end
 
+  describe '#region=' do
+    context "when set to 'us'" do
+      it 'sets the region to US' do
+        configuration = described_class.new
+
+        configuration.region = 'us'
+
+        expect(configuration.region).to eq(:us)
+      end
+    end
+
+    context 'when set to :us' do
+      it 'sets the region to US' do
+        configuration = described_class.new
+
+        configuration.region = :us
+
+        expect(configuration.region).to eq(:us)
+      end
+    end
+
+    context 'when set to an unsupported value' do
+      it 'raises Payrix::InvalidRegionError' do
+        configuration = described_class.new
+
+        expect { configuration.region = true }.to raise_error(Payrix::InvalidRegionError)
+        expect { configuration.region = 0 }.to raise_error(Payrix::InvalidRegionError)
+        expect { configuration.region = :uk }.to raise_error(Payrix::InvalidRegionError)
+        expect { configuration.region = 'uk' }.to raise_error(Payrix::InvalidRegionError)
+        expect { configuration.region = [] }.to raise_error(Payrix::InvalidRegionError)
+        expect { configuration.region = {} }.to raise_error(Payrix::InvalidRegionError)
+      end
+    end
+  end
+
   describe '#url' do
     context 'when environment is not configured and nothing is passed' do
       it 'returns the sandbox URL https://test-api.payrix.com' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,8 @@ require 'payrix'
 require 'webmock/rspec'
 require 'pry'
 
+Payrix.region = :us
+
 RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect


### PR DESCRIPTION
# Description

This PR introduces support for the Payrix Canada API. This API is served through a different set of endpoints.

- https://test-api.payrixcanada.com (sandbox)
- https://api.payrixcanada.com (production)

These differ from the USA API endpoints. Therefore, a new **_required_** region configuration has been introduced in order to specify which API to use. This configuration can be set globally.

```ruby
Payrix.region = :ca
```

It can also be configured on a per-request basis.

```ruby
Payrix::Merchant.retrieve('t1_mer_620acd189522582b3fb7849', { region: :ca })
```