### PR TITLE
Add activity feed API

### DIFF
--- a/graphite-demo/server.js
+++ b/graphite-demo/server.js
@@ -1,0 +1,30 @@
+const express = require('express');
+const app = express();
+const port = 3000;
+
+// Fake data for the activity feed
+const activityFeed = [
+  {
+    id: 1000,
+    title: 'New Photo Uploaded',
+    body: 'Alice uploaded a new photo to her album.'
+  },
+  {
+    id: 2000,
+    title: 'Comment on Post',
+    body: "Bob commented on Charlie's post."
+  },
+  {
+    id: 13,
+    title: 'Status Update',
+    body: 'Charlie updated their status: "Excited about the new project!"'
+  }
+];
+
+app.get('/feed', (req, res) => {
+  res.json(activityFeed);
+});
+
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});


### PR DESCRIPTION
### TL;DR

Added a basic Express server with a mock activity feed endpoint.

### What changed?

Created a new `server.js` file in the graphite-demo directory that:
- Sets up an Express server running on port 3000
- Defines a mock activity feed with sample data
- Implements a GET `/feed` endpoint that returns the activity feed as JSON

### How to test?

1. Install dependencies: `npm install express`
2. Start the server: `node graphite-demo/server.js`
3. Access the endpoint: `curl http://localhost:3000/feed` or visit in a browser
4. Verify that the response contains the mock activity feed data

### Why make this change?

This provides a simple backend API for the graphite demo application to fetch activity feed data, enabling frontend development without requiring a full backend implementation. The mock data allows for testing the activity feed display functionality.